### PR TITLE
Automatic update of System.IO.FileSystem.DriveInfo to 4.3.1

### DIFF
--- a/System.IO.Abstractions/System.IO.Abstractions.csproj
+++ b/System.IO.Abstractions/System.IO.Abstractions.csproj
@@ -25,9 +25,7 @@
         <PackageReference Include="System.IO.FileSystem.AccessControl">
             <Version>4.3.0</Version>
         </PackageReference>
-        <PackageReference Include="System.IO.FileSystem.DriveInfo">
-            <Version>4.3.0</Version>
-        </PackageReference>
+        <PackageReference Include="System.IO.FileSystem.DriveInfo" Version="4.3.1" />
         <PackageReference Include="System.IO.FileSystem.Watcher">
             <Version>4.3.0</Version>
         </PackageReference>


### PR DESCRIPTION
NuKeeper has generated a patch update of `System.IO.FileSystem.DriveInfo` to `4.3.1` from `4.3.0`
`System.IO.FileSystem.DriveInfo 4.3.1` was published at `2017-09-20T20:28:19Z`, 10 months ago

1 project update:
Updated `System.IO.Abstractions\System.IO.Abstractions.csproj` to `System.IO.FileSystem.DriveInfo` `4.3.1` from `4.3.0`

This is an automated update. Merge only if it passes tests

[System.IO.FileSystem.DriveInfo 4.3.1 on NuGet.org](https://www.nuget.org/packages/System.IO.FileSystem.DriveInfo/4.3.1)
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
