### PR TITLE
Automatic update of NUnit3TestAdapter to 3.10.0

### DIFF
--- a/TestHelpers.Tests/TestHelpers.Tests.csproj
+++ b/TestHelpers.Tests/TestHelpers.Tests.csproj
@@ -39,11 +39,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" 
-                      Version="15.0.0"
-                      Condition="'$(TargetFramework)' != 'net40'" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" Condition="'$(TargetFramework)' != 'net40'" />
     <PackageReference Include="nunit" Version="3.8.1" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.9.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.10.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
NuKeeper has generated a minor update of `NUnit3TestAdapter` to `3.10.0` from `3.9.0`
`NUnit3TestAdapter 3.10.0` was published at `2018-03-08T17:05:51Z`, 4 months ago

1 project update:
Updated `TestHelpers.Tests\TestHelpers.Tests.csproj` to `NUnit3TestAdapter` `3.10.0` from `3.9.0`

This is an automated update. Merge only if it passes tests

[NUnit3TestAdapter 3.10.0 on NuGet.org](https://www.nuget.org/packages/NUnit3TestAdapter/3.10.0)
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
