### PR TITLE
Automatic update of Microsoft.NET.Test.Sdk to 15.7.2

### DIFF
--- a/TestHelpers.Tests/TestHelpers.Tests.csproj
+++ b/TestHelpers.Tests/TestHelpers.Tests.csproj
@@ -39,9 +39,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" 
-                      Version="15.0.0"
-                      Condition="'$(TargetFramework)' != 'net40'" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.2" />
     <PackageReference Include="nunit" Version="3.8.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.9.0" />
   </ItemGroup>


### PR DESCRIPTION
NuKeeper has generated a minor update of `Microsoft.NET.Test.Sdk` to `15.7.2` from `15.0.0`
`Microsoft.NET.Test.Sdk 15.7.2` was published at `2018-05-16T07:37:07Z`, 2 months ago

1 project update:
Updated `TestHelpers.Tests\TestHelpers.Tests.csproj` to `Microsoft.NET.Test.Sdk` `15.7.2` from `15.0.0`

This is an automated update. Merge only if it passes tests

[Microsoft.NET.Test.Sdk 15.7.2 on NuGet.org](https://www.nuget.org/packages/Microsoft.NET.Test.Sdk/15.7.2)
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
