### PR TITLE
Automatic update of NUnit to 3.12.0

### DIFF
--- a/TestHelpers.Tests/TestHelpers.Tests.csproj
+++ b/TestHelpers.Tests/TestHelpers.Tests.csproj
@@ -43,7 +43,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="nunit" Version="3.8.1" />
+    <PackageReference Include="nunit" Version="3.12.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.9.0" />
   </ItemGroup>
 


### PR DESCRIPTION
NuKeeper has generated a minor update of `NUnit` to `3.12.0` from `3.8.1`
`NUnit 3.12.0` was published at `2019-05-15T00:24:28Z`, 1 year ago

1 project update:
Updated `TestHelpers.Tests/TestHelpers.Tests.csproj` to `NUnit` `3.12.0` from `3.8.1`

[NUnit 3.12.0 on NuGet.org](https://www.nuget.org/packages/NUnit/3.12.0)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
