### PR TITLE
Automatic update of System.Security.AccessControl to 4.7.0

### DIFF
--- a/TestingHelpers/TestingHelpers.csproj
+++ b/TestingHelpers/TestingHelpers.csproj
@@ -34,6 +34,6 @@
     <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.4'">
         <PackageReference Include="System.Diagnostics.Contracts" Version="4.3.0" />
         <PackageReference Include="System.Runtime.Serialization.Formatters" Version="4.3.0" />
-        <PackageReference Include="System.Security.AccessControl" Version="4.3.0" />
+        <PackageReference Include="System.Security.AccessControl" Version="4.7.0" />
     </ItemGroup>
 </Project>


### PR DESCRIPTION
NuKeeper has generated a minor update of `System.Security.AccessControl` to `4.7.0` from `4.3.0`
`System.Security.AccessControl 4.7.0` was published at `2019-12-03T16:41:30Z`, 5 months ago

1 project update:
Updated `TestingHelpers/TestingHelpers.csproj` to `System.Security.AccessControl` `4.7.0` from `4.3.0`

[System.Security.AccessControl 4.7.0 on NuGet.org](https://www.nuget.org/packages/System.Security.AccessControl/4.7.0)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
