### PR TITLE
Automatic update of System.IO.FileSystem.DriveInfo to 4.3.1

### DIFF
--- a/System.IO.Abstractions/System.IO.Abstractions.csproj
+++ b/System.IO.Abstractions/System.IO.Abstractions.csproj
@@ -26,7 +26,7 @@
             <Version>4.3.0</Version>
         </PackageReference>
         <PackageReference Include="System.IO.FileSystem.DriveInfo">
-            <Version>4.3.0</Version>
+            <Version>4.3.1</Version>
         </PackageReference>
         <PackageReference Include="System.IO.FileSystem.Watcher">
             <Version>4.3.0</Version>


### PR DESCRIPTION
NuKeeper has generated a patch update of `System.IO.FileSystem.DriveInfo` to `4.3.1` from `4.3.0`
`System.IO.FileSystem.DriveInfo 4.3.1` was published at `2017-09-20T20:28:19Z`, 2 years and 8 months ago

1 project update:
Updated `System.IO.Abstractions/System.IO.Abstractions.csproj` to `System.IO.FileSystem.DriveInfo` `4.3.1` from `4.3.0`

[System.IO.FileSystem.DriveInfo 4.3.1 on NuGet.org](https://www.nuget.org/packages/System.IO.FileSystem.DriveInfo/4.3.1)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
